### PR TITLE
Add support for CC extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,14 @@ CFLAGS += -Wall -Wpointer-arith -Wextra -Wmissing-prototypes -Wstrict-prototypes
 CFLAGS += -fPIC -ftree-vectorize -fvisibility=hidden -I. -Os -ggdb -fdiagnostics-color=auto -flto
 LDFLAGS += -lm -lc -flto=3
 
+# Detect GCC extensions by trial & error
+SUPPORT_LTO = $(shell (echo "" | $(CC) -flto -xc - -o /dev/stdout && /dev/true) || /dev/false)
+$(info $(SUPPORT_LTO))
+
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
-SRC   := $(call rwildcard, ./src/, *.c)
-OBJ   := $(patsubst %.c,%.o, $(SRC))
-TESTS := $(call rwildcard, ./test/, *.c)
+SRC   = $(call rwildcard, ./src/, *.c)
+OBJ   = $(patsubst %.c,%.o, $(SRC))
+TESTS = $(call rwildcard, ./test/, *.c)
 
 ifeq ($(LINKTYPE),static)
 	LIB = $(LIB_NAME).a

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,15 @@ CFLAGS += -fPIC -ftree-vectorize -fvisibility=hidden -I. -Os -ggdb
 LDFLAGS += -lm -lc
 
 # Detect GCC extensions by trial & exception (try to compile an empty file with the given flag)
-SUPPORT_LTO = $(shell (echo "" | $(CC) -flto -xc - -o /dev/stdout && echo "yep") || echo "nope")
-$(info $(SUPPORT_LTO))
+testccflag=$(shell (echo "" | $(CC) $1 -xc - -o /dev/null > /dev/null 2>&1 && echo "yep") || echo "nope")
+SUPPORT_LTO = $(call testccflag, -flto)
+$(info LTO: $(SUPPORT_LTO))
 ifeq ($(SUPPORT_LTO),yep)
 	CFLAGS += -flto
 	LDFLAGS += -flto=3
 endif
-SUPPORT_PRETTY_OUT = $(shell (echo "" | $(CC) -fdiagnostics-color=auto -xc - -o /dev/stdout && echo "yep") || echo "nope")
-$(info $(SUPPORT_PRETTY_OUT))
+SUPPORT_PRETTY_OUT = $(call testccflag, -fdiagnostics-color=auto)
+$(info color: $(SUPPORT_PRETTY_OUT))
 ifeq ($(SUPPORT_PRETTY_OUT),yep)
 	CFLAGS += -fdiagnostics-color=auto
 	LDFLAGS += -fdiagnostics-color=auto

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,22 @@ INC_INSTALL_DIR := $(PREFIX)/include/collections
 USER_INCLUDES:= ./src/collections.h ./src/queue/queue.h
 
 CFLAGS += -Wall -Wpointer-arith -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wconversion -Wunused-function
-CFLAGS += -fPIC -ftree-vectorize -fvisibility=hidden -I. -Os -ggdb -fdiagnostics-color=auto -flto
-LDFLAGS += -lm -lc -flto=3
+CFLAGS += -fPIC -ftree-vectorize -fvisibility=hidden -I. -Os -ggdb
+LDFLAGS += -lm -lc
 
-# Detect GCC extensions by trial & error
-SUPPORT_LTO = $(shell (echo "" | $(CC) -flto -xc - -o /dev/stdout && /bin/true) || /bin/false)
+# Detect GCC extensions by trial & exception (try to compile an empty file with the given flag)
+SUPPORT_LTO = $(shell (echo "" | $(CC) -flto -xc - -o /dev/stdout && echo "yep") || echo "nope")
 $(info $(SUPPORT_LTO))
+ifeq ($(SUPPORT_LTO),yep)
+	CFLAGS += -flto
+	LDFLAGS += -flto=3
+endif
+SUPPORT_PRETTY_OUT = $(shell (echo "" | $(CC) -fdiagnostics-color=auto -xc - -o /dev/stdout && echo "yep") || echo "nope")
+$(info $(SUPPORT_PRETTY_OUT))
+ifeq ($(SUPPORT_PRETTY_OUT),yep)
+	CFLAGS += -fdiagnostics-color=auto
+	LDFLAGS += -fdiagnostics-color=auto
+endif
 
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
 SRC   = $(call rwildcard, ./src/, *.c)

--- a/Makefile
+++ b/Makefile
@@ -10,24 +10,12 @@ MANDIR := $(PREFIX)/share/man
 INC_INSTALL_DIR := $(PREFIX)/include/collections
 USER_INCLUDES:= ./src/collections.h ./src/queue/queue.h
 
-CFLAGS += -Wall -Wpointer-arith -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wconversion -Wunused-function
-CFLAGS += -fPIC -ftree-vectorize -fvisibility=hidden -I. -Os -ggdb
-LDFLAGS += -lm -lc
 
-# Detect GCC extensions by trial & exception (try to compile an empty file with the given flag)
-testccflag=$(shell (echo "" | $(CC) $1 -xc - -o /dev/null > /dev/null 2>&1 && echo "yep") || echo "nope")
-SUPPORT_LTO = $(call testccflag, -flto)
-$(info LTO: $(SUPPORT_LTO))
-ifeq ($(SUPPORT_LTO),yep)
-	CFLAGS += -flto
-	LDFLAGS += -flto=3
-endif
-SUPPORT_PRETTY_OUT = $(call testccflag, -fdiagnostics-color=auto)
-$(info color: $(SUPPORT_PRETTY_OUT))
-ifeq ($(SUPPORT_PRETTY_OUT),yep)
-	CFLAGS += -fdiagnostics-color=auto
-	LDFLAGS += -fdiagnostics-color=auto
-endif
+CFLAGS += -Wall -Wpointer-arith -Wextra -Wmissing-prototypes -Wstrict-prototypes -Wconversion -Wunused-function -fPIC -ftree-vectorize -fvisibility=hidden -I. -Os -ggdb
+# Detect CC extensions by trial & exception (try to compile an empty file with the given flag)
+optccflag=$(if ifeq ($(shell echo "" | $(CC) $1 -xc - -o /dev/null > /dev/null 2>&1 && echo yep),yep), $(if ifneq ($2,),$(info $2: yep))$1, $(if ifneq ($2,),$(info $2: nope)))
+CFLAGS += $(call optccflag, -flto, LTO) $(call optccflag, -fdiagnostics-color=auto, color)
+LDFLAGS += -lm -lc $(call optccflag, -flto=3)
 
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
 SRC   = $(call rwildcard, ./src/, *.c)
@@ -46,14 +34,10 @@ install: all
 	mkdir -p $(DESTDIR)$(INC_INSTALL_DIR)
 	install -p -m 644 $(USER_INCLUDES) $(DESTDIR)$(INC_INSTALL_DIR)
 	mkdir -p $(DESTDIR)$(LIB_INSTALL_DIR)
-ifeq ($(LINKTYPE),static)
-		install -m 644 $(LIB) $(DESTDIR)$(LIB_INSTALL_DIR)
-else
-		install -m 755 $(LIB) $(DESTDIR)$(LIB_INSTALL_DIR)
-endif
+	# Static/dynamic libraries need different permissions
+	install -m $(if ifeq ($(LINKTYPE),static),644,755) $(LIB) $(DESTDIR)$(LIB_INSTALL_DIR)
 
 includes: ./include $(patsubst ./src/%,./include/%,$(USER_INCLUDES))
-
 
 uninstall:
 	for f in $(USER_INCLUDES); do rm -f $(DESTDIR)$(INC_INSTALL_DIR)/$${f}; done

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ CFLAGS += -fPIC -ftree-vectorize -fvisibility=hidden -I. -Os -ggdb -fdiagnostics
 LDFLAGS += -lm -lc -flto=3
 
 # Detect GCC extensions by trial & error
-SUPPORT_LTO = $(shell (echo "" | $(CC) -flto -xc - -o /dev/stdout && /dev/true) || /dev/false)
+SUPPORT_LTO = $(shell (echo "" | $(CC) -flto -xc - -o /dev/stdout && /bin/true) || /bin/false)
 $(info $(SUPPORT_LTO))
 
 rwildcard=$(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))


### PR DESCRIPTION
Basically, we get a smaller binary size & prettier output if we use LTO and pretty output, but they aren't supported everywhere.
Solution: try to compile an empty file with the given flag to detect whether it is supported.